### PR TITLE
Fix config typos in staticman and navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ navbar-links:
     - Leveraging Multiple AIs for Reliable Research and Content Creation: "https://kaptandatasolutions.github.io/2025-05-04-KAPTAN-DATA-SOLUTIONS-ITEMS/"
     - Podcast - Agent2Agent (A2A) Protocol for Enhanced AI Agent Collaboration: "https://kaptandatasolutions.github.io/2025-04-14-A2A-protocol/"
     - Understanding ARL: "https://kaptandatasolutions.github.io/2024-10-24-ARL0-ARL1/"
-    - Revoltionizing: "https://kaptandatasolutions.github.io/2024-10-02-Revolutionizing/"
+    - Revolutionizing: "https://kaptandatasolutions.github.io/2024-10-02-Revolutionizing/"
     - Surgical Robots: "https://kaptandatasolutions.github.io/2024-10-11-Robotic-Control-Strategies-at-Ganymed-Robotics/"
     - Podcast Optimizing Control Charts: "https://kaptandatasolutions.github.io/2024-10-26-Podcast-ARL/"
     - Podcast Automated Starshot Analysis: "https://kaptandatasolutions.github.io/2024-10-09-Podcast-Starshot-By-Kaptan-data-solutions-Pylinac/"

--- a/_staticman.yml
+++ b/_staticman.yml
@@ -7,7 +7,7 @@ comments:
   requiredFields: ["name", "email", "message"]
 
   # Nom de la branche (doit correspondre à la branche utilisée pour le site)
-  branch: "master"
+  branch: "main"
 
   # Message du commit lors de la création d’un nouveau commentaire
   commitMessage: "New comment by {fields.name}"


### PR DESCRIPTION
## Summary
- fix misspelled navigation label
- update Staticman config to use `main` branch

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_684437206554832895c46f3e48f649b2