### PR TITLE
Add language selector to navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ title: home
 
 # Your name to show in the footer
 author: Kaptan Data Solutions
+languages: [en, fr]
 
 ###############################################
 # --- List of links in the navigation bar --- #
@@ -213,8 +214,8 @@ footer-hover-col: "#f549f4"
 #  - "/assets/css/custom-styles.css"
 
 # If you have common JavaScript files that should be included in every page, list them here
-#site-js:
-#  - "/assets/js/custom-script.js"
+site-js:
+  - "/assets/js/lang.js"
 
 #################################
 # --- Web Analytics Section --- #

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,32 +20,41 @@
       {%- for link in site.navbar-links -%}
         {%- if link[1].first %}
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ link[0] }}</a>
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-i18n="{{ link[0] | slugify }}">{{ link[0] }}</a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
               {%- for childlink in link[1] -%}
                 {%- for linkparts in childlink %}
-                  <a class="dropdown-item" href="{{ linkparts[1] | relative_url }}">{{ linkparts[0] }}</a>
+                  <a class="dropdown-item" data-i18n="{{ linkparts[0] | slugify }}" href="{{ linkparts[1] | relative_url }}">{{ linkparts[0] }}</a>
                 {%- endfor -%}
               {%- endfor %}
             </div>
           </li>
         {% else %}
           <li class="nav-item">
-            <a class="nav-link" href="{{ link[1] | relative_url }}">{{ link[0] }}</a>
+            <a class="nav-link" data-i18n="{{ link[0] | slugify }}" href="{{ link[1] | relative_url }}">{{ link[0] }}</a>
           </li>
         {%- endif -%}
       {%- endfor -%}
-      
+
+      <!-- Language selector -->
+      <li class="nav-item">
+        <select id="lang-select" class="nav-link">
+          {%- for lang in site.languages -%}
+            <option value="{{ lang }}">{{ lang | upcase }}</option>
+          {%- endfor -%}
+        </select>
+      </li>
+
       <!-- Boutons Auth0 avec des événements onclick explicites -->
       <li class="nav-item">
-        <button id="auth0-login-btn" class="btn btn-sm btn-primary nav-link" style="margin: 0.5rem;" onclick="console.log('Login clicked'); document.dispatchEvent(new Event('auth0login'));">Login</button>
-        <button id="auth0-logout-btn" class="btn btn-sm btn-outline-primary nav-link" style="display: none; margin: 0.5rem;" onclick="console.log('Logout clicked'); document.dispatchEvent(new Event('auth0logout'));">Logout</button>
+        <button id="auth0-login-btn" class="btn btn-sm btn-primary nav-link" style="margin: 0.5rem;" data-i18n="login" onclick="console.log('Login clicked'); document.dispatchEvent(new Event('auth0login'));">Login</button>
+        <button id="auth0-logout-btn" class="btn btn-sm btn-outline-primary nav-link" style="display: none; margin: 0.5rem;" data-i18n="logout" onclick="console.log('Logout clicked'); document.dispatchEvent(new Event('auth0logout'));">Logout</button>
       </li>
       {% if site.post_search %}
         <li class="nav-item">
           <a class="nav-link" id="nav-search-link" href="#" title="Search">
             <span id="nav-search-icon" class="fa fa-search"></span>
-            <span id="nav-search-text">Search</span>
+            <span id="nav-search-text" data-i18n="search">Search</span>
           </a>
         </li>
       {%- endif -%}
@@ -69,5 +78,29 @@
   {% endif %}
 
 </nav>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var select = document.getElementById('lang-select');
+    if (!select) return;
+
+    var params = new URLSearchParams(window.location.search);
+    var lang = params.get('lang') || localStorage.getItem('lang') || select.value;
+    select.value = lang;
+    if (typeof applyTranslations === 'function') {
+      applyTranslations(lang);
+    }
+
+    select.addEventListener('change', function () {
+      var chosen = this.value;
+      localStorage.setItem('lang', chosen);
+      params.set('lang', chosen);
+      history.replaceState(null, '', '?' + params.toString());
+      if (typeof applyTranslations === 'function') {
+        applyTranslations(chosen);
+      }
+    });
+  });
+</script>
 
 {% include search.html %}

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -3,7 +3,7 @@
 <div id="beautifuljekyll-search-overlay">
 
   <div id="nav-search-exit" title="Exit search">✕</div>
-  <input type="text" id="nav-search-input" placeholder="Search">
+  <input type="text" id="nav-search-input" placeholder="Search" data-i18n="search">
   <ul id="search-results-container"></ul>
   
   <script src="https://unpkg.com/simple-jekyll-search@latest/dest/simple-jekyll-search.min.js"></script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -106,14 +106,14 @@ layout: page
   <li class="page-item previous">
     <a class="page-link" href="{{ paginator.previous_page_path | absolute_url }}">
       <i class="fas fa-arrow-left" alt="Newer Posts"></i>
-      <span class="d-none d-sm-inline-block">Newer Posts</span>
+      <span class="d-none d-sm-inline-block" data-i18n="newer-posts">Newer Posts</span>
     </a>
   </li>
   {% endif %}
   {% if paginator.next_page %}
   <li class="page-item next">
     <a class="page-link" href="{{ paginator.next_page_path | absolute_url }}">
-      <span class="d-none d-sm-inline-block">Older Posts</span>
+      <span class="d-none d-sm-inline-block" data-i18n="older-posts">Older Posts</span>
       <i class="fas fa-arrow-right" alt="Older Posts"></i>
     </a>
   </li>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -164,3 +164,14 @@ form {
 @media (max-width: 360px){
   .contact-floating{display:none;}
 }
+
+/* Language selector styling */
+#lang-select {
+  margin: 0.5rem;
+  background-color: transparent;
+  border: 1px solid #fff;
+  color: #fff;
+  border-radius: 4px;
+  padding: 0.25rem;
+}
+#lang-select option { color: #000; }

--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -1,0 +1,40 @@
+(function() {
+  window.I18N_DICT = {
+    en: {
+      "about-us": "About Us",
+      "contact": "Contact",
+      "login": "Login",
+      "logout": "Logout",
+      "search": "Search",
+      "newer-posts": "Newer Posts",
+      "older-posts": "Older Posts"
+    },
+    fr: {
+      "about-us": "À propos",
+      "contact": "Contact",
+      "login": "Connexion",
+      "logout": "Déconnexion",
+      "search": "Recherche",
+      "newer-posts": "Articles récents",
+      "older-posts": "Articles plus anciens"
+    }
+  };
+
+  window.applyTranslations = function(lang) {
+    var dict = I18N_DICT[lang];
+    if (!dict) return;
+    document.querySelectorAll('[data-i18n]').forEach(function(el) {
+      var key = el.getAttribute('data-i18n');
+      var text = dict[key];
+      if (text) {
+        if ('placeholder' in el) {
+          el.placeholder = text;
+        }
+        if (el.textContent !== undefined && !el.children.length) {
+          el.textContent = text;
+        }
+      }
+    });
+    document.documentElement.lang = lang;
+  };
+})();


### PR DESCRIPTION
## Summary
- list available languages in `_config.yml`
- add language dropdown in navbar
- implement script to persist selected language
- style new language selector
- add dynamic translation support using `assets/js/lang.js`

## Testing
- `bundle exec appraisal jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3b56ef008328a738865360e4a360