### PR TITLE
Add exit search translation fix

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -2,7 +2,7 @@
 
 <div id="beautifuljekyll-search-overlay">
 
-  <div id="nav-search-exit" title="Exit search">✕</div>
+  <div id="nav-search-exit" title="Exit search" data-i18n="exit-search">✕</div>
   <input type="text" id="nav-search-input" placeholder="Search" data-i18n="search">
   <ul id="search-results-container"></ul>
   

--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -7,7 +7,8 @@
       "logout": "Logout",
       "search": "Search",
       "newer-posts": "Newer Posts",
-      "older-posts": "Older Posts"
+      "older-posts": "Older Posts",
+      "exit-search": "Exit search"
     },
     fr: {
       "about-us": "À propos",
@@ -16,7 +17,8 @@
       "logout": "Déconnexion",
       "search": "Recherche",
       "newer-posts": "Articles récents",
-      "older-posts": "Articles plus anciens"
+      "older-posts": "Articles plus anciens",
+      "exit-search": "Fermer la recherche"
     }
   };
 
@@ -31,6 +33,9 @@
         }
         if (el.textContent !== undefined && !el.children.length) {
           el.textContent = text;
+        }
+        if (el.hasAttribute('title')) {
+          el.title = text;
         }
       }
     });


### PR DESCRIPTION
## Summary
- added `data-i18n="exit-search"` to search overlay close button
- provided translations for `exit-search` in English and French
- translate `title` attributes when applying translations
- updated French translation wording for the exit button

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d664c1a18832882b5ba07fabacea8