### PR TITLE
Add jekyll-polyglot plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,6 @@ gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 # Pour supprimer l’avertissement BigDecimal
 gem "bigdecimal"
+
+# Advanced plugin for multilanguage support
+gem "jekyll-polyglot", "~> 1.7"

--- a/README.md
+++ b/README.md
@@ -34,4 +34,11 @@ So, if you're ready to embark on a data-driven adventure, join us. Together, we 
 
 **[[Contact us]](kaptandatasolutions@gmail.com)** 
 
-**[[visit our website solutions portfolio]](https://kaptan-data.streamlit.app/)** 
+**[[visit our website solutions portfolio]](https://kaptan-data.streamlit.app/)**
+
+## Internationalization
+
+The site now uses the **jekyll-polyglot** plugin to handle multiple languages.
+Pages can be translated by creating language-specific versions like `about_us.fr.md`.
+The plugin will automatically route visitors to the correct language based on
+their selection or browser settings.

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,11 @@ title: home
 # Your name to show in the footer
 author: Kaptan Data Solutions
 languages: [en, fr]
+default_lang: en
+exclude_from_localization:
+  - assets
+  - Gemfile
+  - Gemfile.lock
 
 ###############################################
 # --- List of links in the navigation bar --- #
@@ -350,6 +355,7 @@ exclude:
 plugins:
   - jekyll-paginate
   - jekyll-sitemap
+  - jekyll-polyglot
 
 # Beautiful Jekyll / Dean Attali
 # 2fc73a3a967e97599c9763d05e564189


### PR DESCRIPTION
## Summary
- enable multilingual support with jekyll-polyglot
- document internationalization in the README

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcc2dca24832885cbcf6e4d375437