### PR TITLE
Fix language selection script

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -87,8 +87,6 @@
     var params = new URLSearchParams(window.location.search);
     var lang = params.get('lang') || localStorage.getItem('lang') || select.value;
     // Récupération de la langue dans l’URL, le localStorage ou la valeur par défaut du select
-    var params = new URLSearchParams(window.location.search);
-    var lang = params.get('lang') || localStorage.getItem('lang') || select.value;
 
     // Liste des langues disponibles (Jekyll)
     var available = {{ site.languages | jsonify }};
@@ -108,10 +106,9 @@
     }
 
 
-<script>
   document.addEventListener('DOMContentLoaded', function () {
     var params = new URLSearchParams(window.location.search);
-    var select = document.querySelector('#language-select');
+    var select = document.querySelector('#lang-select');
 
     select.addEventListener('change', function () {
       var chosen = this.value;


### PR DESCRIPTION
## Summary
- correct DOMContentLoaded handler in `nav.html`
- remove duplicate parameter declarations
- fix selector and ensure single script block

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: jekyll executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db57ad04c8328b32298043df959f2